### PR TITLE
Remove leading zero from gasLimit field on Block Header notifications

### DIFF
--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/BlockHeaderNotification.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/subscribe/BlockHeaderNotification.java
@@ -43,7 +43,7 @@ public class BlockHeaderNotification implements EthSubscriptionNotificationDTO {
     public BlockHeaderNotification(Block block) {
         difficulty = TypeConverter.toQuantityJsonHex(block.getDifficulty().getBytes());
         extraData = TypeConverter.toUnformattedJsonHex(block.getExtraData());
-        gasLimit = TypeConverter.toJsonHex(block.getGasLimit());
+        gasLimit = TypeConverter.toQuantityJsonHex(block.getGasLimit());
         gasUsed = TypeConverter.toQuantityJsonHex(block.getGasUsed());
         logsBloom = TypeConverter.toJsonHex(block.getLogBloom());
         miner = TypeConverter.toJsonHex(block.getCoinbase().getBytes());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR removes the leading zero from the gasLimit field value of the Block Header subscriptions notifications

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR aims to improve compatibility with Ethereum's native tools like the official Go client library, and solve an issue where subscribing to new heads leads to a json.UnmarshalTypeError "hex number with leading zero digits"  when trying to read the gasLimit field from a Block Header notification.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
